### PR TITLE
Add hb_font_set_variations func

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -287,6 +287,26 @@ cdef class Font:
         x, y = value
         hb_font_set_scale(self._hb_font, x, y)
 
+    def set_variations(self, variations: Dict[str, float]) -> None:
+        cdef unsigned int size
+        cdef hb_variation_t* hb_variations
+        cdef bytes packed
+        cdef hb_variation_t variation
+        size = len(variations)
+        hb_variations = <hb_variation_t*>malloc(size * sizeof(hb_variation_t))
+        if not hb_variations:
+            raise MemoryError()
+
+        try:
+            for i, (name, value) in enumerate(variations.items()):
+                packed = name.encode()
+                variation.tag = hb_tag_from_string(packed, -1)
+                variation.value = value
+                hb_variations[i] = variation
+            hb_font_set_variations(self._hb_font, hb_variations, size)
+        finally:
+            free(hb_variations)
+
 
 cdef hb_position_t _glyph_h_advance_func(hb_font_t* font, void* font_data,
                                          hb_codepoint_t glyph,

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -141,6 +141,9 @@ cdef extern from "hb.h":
         hb_codepoint_t glyph,
         char *name, unsigned int size,
         void *user_data)
+    ctypedef struct hb_variation_t:
+        hb_tag_t tag
+        float value
 
     hb_font_funcs_t* hb_font_funcs_create()
     void hb_font_funcs_set_glyph_h_advance_func(
@@ -164,6 +167,10 @@ cdef extern from "hb.h":
         void* font_data, hb_destroy_func_t destroy)
     void hb_font_get_scale(hb_font_t* font, int* x_scale, int* y_scale)
     void hb_font_set_scale(hb_font_t* font, int x_scale, int y_scale)
+    void hb_font_set_variations(
+        hb_font_t* font,
+        const hb_variation_t* variations,
+        unsigned int variations_length)
     void hb_font_destroy(hb_font_t* font)
 
     # hb-shape.h


### PR DESCRIPTION
This pr adds the hb function [hb_font_set_variations](https://harfbuzz.github.io/harfbuzz-hb-font.html#hb-font-set-variations).

I've added a method to the font class so users can set variations using a dict in the following manner. 

```
font.variation({"wght": 300, "slnt": -20})
```

I'm unsure whether to keep the method name singular? the hb function is plural.

I need to implement this so I can generate diff images using freetype-py and this lib. If I need more variable related structs and functions, I'll add them. Also, thanks for making this binding. It's the best one imo.