### PR TITLE
Unicode cluster index

### DIFF
--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from charfbuzz cimport *
 from libc.stdlib cimport free, malloc
 from libc.string cimport const_char

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -1,3 +1,4 @@
+from libc.stdint cimport uint16_t, uint32_t
 
 
 cdef extern from "hb.h":
@@ -87,6 +88,14 @@ cdef extern from "hb.h":
     void hb_buffer_add_utf8(
         hb_buffer_t* buffer,
         const char* text, int text_length,
+        unsigned int item_offset, int item_length)
+    void hb_buffer_add_utf16(
+        hb_buffer_t* buffer,
+        const uint16_t* text, int text_length,
+        unsigned int item_offset, int item_length)
+    void hb_buffer_add_utf32(
+        hb_buffer_t* buffer,
+        const uint32_t* text, int text_length,
         unsigned int item_offset, int item_length)
     void hb_buffer_guess_segment_properties(hb_buffer_t* buffer)
     hb_direction_t hb_buffer_get_direction(hb_buffer_t* buffer)


### PR DESCRIPTION
The returned info.cluster value after using `Buffer.add_str` should now match the indexes of the input python unicode string.
This works with both narrow and wide python builds (python3 is always wide).
The `add_utf8` method can be useful when reading bytes from a UTF-8 text file.

Note I only tested this locally. We need to add a proper test suite at some point.

Fixes #9 

