### PR TITLE
initialize C structs inside __cinit__; deprecate alternative create() constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
         - PYTHON=python2
         - PIP_INSTALL_OPTIONS="--upgrade --user"
 
+branches:
+  only:
+    # skip PR branches, only build from master and tagged commits
+    - master
+    - /^v\d+\.\d+.*$/
+
 install:
   - $PYTHON -m pip install $PIP_INSTALL_OPTIONS pip
   - $PYTHON -m pip install $PIP_INSTALL_OPTIONS cibuildwheel==0.10.0

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ with open(sys.argv[1], 'rb') as fontfile:
 
 text = sys.argv[2]
 
-face = hb.Face.create(fontdata)
-font = hb.Font.create(face)
+face = hb.Face(fontdata)
+font = hb.Font(face)
 upem = face.upem
 
 font.scale = (upem, upem)
 hb.ot_font_set_funcs(font)
 
-buf = hb.Buffer.create()
+buf = hb.Buffer()
 
 buf.add_str(text)
 buf.guess_segment_properties()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ environment:
     TWINE_PASSWORD:
       secure: H3o/uI5KfKGTFumKKW68hg==
 
+branches:
+  only:
+    # skip PR branches, only build from master and tagged commits
+    - master
+    - /^v\d+\.\d+.*$/
+
 install:
   - python -m pip install --upgrade pip
   - pip install cibuildwheel==0.10.0

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -63,16 +63,16 @@ cdef class Buffer:
     cdef hb_buffer_t* _hb_buffer
 
     def __cinit__(self):
-        self._hb_buffer = NULL
+        self._hb_buffer = hb_buffer_create()
 
     def __dealloc__(self):
         if self._hb_buffer is not NULL:
             hb_buffer_destroy(self._hb_buffer)
 
+    # DEPRECATED: use the normal constructor
     @classmethod
     def create(cls):
         cdef Buffer inst = cls()
-        inst._hb_buffer = hb_buffer_create()
         return inst
 
     @property
@@ -232,19 +232,19 @@ cdef class Face:
     cdef hb_face_t* _hb_face
     cdef object _reference_table_func
 
-    def __cinit__(self):
-        self._hb_face = NULL
+    def __cinit__(self, bytes blob, int index=0):
+        cdef hb_blob_t* hb_blob = hb_blob_create(
+            blob, len(blob), HB_MEMORY_MODE_READONLY, NULL, NULL)
+        self._hb_face = hb_face_create(hb_blob, index)
 
     def __dealloc__(self):
         if self._hb_face is not NULL:
             hb_face_destroy(self._hb_face)
 
+    # DEPRECATED: use the normal constructor
     @classmethod
     def create(cls, bytes blob, int index=0):
-        cdef Face inst = cls()
-        cdef hb_blob_t* hb_blob = hb_blob_create(
-            blob, len(blob), HB_MEMORY_MODE_READONLY, NULL, NULL)
-        inst._hb_face = hb_face_create(hb_blob, index)
+        cdef Face inst = cls(blob, index)
         return inst
 
     @classmethod
@@ -277,19 +277,19 @@ cdef class Font:
     cdef Face _face
     cdef FontFuncs _ffuncs
 
-    def __cinit__(self):
-        self._hb_font = NULL
+    def __cinit__(self, Face face):
+        self._hb_font = hb_font_create(face._hb_face)
+        self._face = face
 
     def __dealloc__(self):
         if self._hb_font is not NULL:
             hb_font_destroy(self._hb_font)
         self._face = self._ffuncs = None
 
+    # DEPRECATED: use the normal constructor
     @classmethod
     def create(cls, face: Face):
-        cdef Font inst = cls()
-        inst._hb_font = hb_font_create(face._hb_face)
-        inst._face = face
+        cdef Font inst = cls(face)
         return inst
 
     @property
@@ -374,16 +374,16 @@ cdef class FontFuncs:
     cdef object _nominal_glyph_func
 
     def __cinit__(self):
-        self._hb_ffuncs = NULL
+        self._hb_ffuncs = hb_font_funcs_create()
 
     def __dealloc__(self):
         if self._hb_ffuncs is not NULL:
             hb_font_funcs_destroy(self._hb_ffuncs)
 
+    # DEPRECATED: use the normal constructor
     @classmethod
     def create(cls):
         cdef FontFuncs inst = cls()
-        inst._hb_ffuncs = hb_font_funcs_create()
         return inst
 
     def set_glyph_h_advance_func(self,

--- a/src/uharfbuzz/_harfbuzz.pyx
+++ b/src/uharfbuzz/_harfbuzz.pyx
@@ -64,6 +64,8 @@ cdef class Buffer:
 
     def __cinit__(self):
         self._hb_buffer = hb_buffer_create()
+        if not hb_buffer_allocation_successful(self._hb_buffer):
+            raise MemoryError()
 
     def __dealloc__(self):
         if self._hb_buffer is not NULL:

--- a/src/uharfbuzz/charfbuzz.pxd
+++ b/src/uharfbuzz/charfbuzz.pxd
@@ -81,6 +81,7 @@ cdef extern from "hb.h":
         hb_var_int_t var
 
     hb_buffer_t* hb_buffer_create()
+    hb_bool_t hb_buffer_allocation_successful(hb_buffer_t* buffer)
     void hb_buffer_add_codepoints(
         hb_buffer_t* buffer,
         const hb_codepoint_t* text, int text_length,


### PR DESCRIPTION
Following discussions at https://github.com/trufont/uharfbuzz/issues/10#issuecomment-445481033

Buffer, Face, Font and FontFuncs can now be instantiated using the regular python constructor syntax (e.g. `Buffer()` as opposed to `Buffer.create()`)
The old `create` classmethod constructors still work but are deprecated.